### PR TITLE
Hide '}' in error message from formatting machinery

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -106,7 +106,9 @@ impl Template {
                 }
             }
 
-            bail!("missing closing '}'")
+            // Hide '}' in this error message from the formatting machinery in bail macro
+            let msg = "missing closing '}'";
+            bail!(msg)
         }
 
         fn environ(


### PR DESCRIPTION
I am considering supporting https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html in a future version of the bail macro, which would make e.g. `{v}` interpolate a variable called `v`, matching the standard library macros:

```rust
bail!("error {v}");  // equivalent to bail!("error {}", v)
```

I've been looking into how widely used `{`/`}` is in bail macro error messages. It looks like this is one of only very few places where it's used intentionally as a `{` or `}` character, as opposed to someone writing `{v}` in the message and expecting it to interpolate the value of `v` (not realizing it doesn't do that currently). If we can write this one a different way, I think it would be reasonable to provide the interpolating behavior from RFC 2795 in the future.